### PR TITLE
feat: Add support for destination-less report

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,12 @@ use lettre::{
 use serde::{Deserialize, Serialize};
 use tokio::time::{sleep, Duration};
 
+#[derive(Debug, PartialEq, Clone)]
+pub enum ReportType {
+    PDF,
+    Cache,
+}
+
 #[derive(Debug, Clone)]
 pub struct SmtpConfig {
     pub from_email: String,
@@ -104,6 +110,7 @@ pub async fn generate_report(
     user_pass: &str,
     web_url: &str,
     timezone: &str,
+    report_type: ReportType,
 ) -> Result<(Vec<u8>, String), anyhow::Error> {
     let dashboard_id = &dashboard.dashboard;
     let folder_id = &dashboard.folder;
@@ -179,6 +186,10 @@ pub async fn generate_report(
     sleep(Duration::from_secs(5)).await;
 
     let timerange = &dashboard.timerange;
+    let search_type = match report_type.clone() {
+        ReportType::Cache => "ui",
+        _ => "reports",
+    };
 
     // dashboard link in the email should contain data of the same period as the report
     let (dashb_url, email_dashb_url) = match timerange.range_type {
@@ -186,7 +197,7 @@ pub async fn generate_report(
             let period = &timerange.period;
             let (time_duration, time_unit) = period.split_at(period.len() - 1);
             let dashb_url = format!(
-                "{web_url}/dashboards/view?org_identifier={org_id}&dashboard={dashboard_id}&folder={folder_id}&tab={tab_id}&refresh=Off&searchtype=reports&period={period}&timezone={timezone}&var-Dynamic+filters=%255B%255D&print=true{dashb_vars}",
+                "{web_url}/dashboards/view?org_identifier={org_id}&dashboard={dashboard_id}&folder={folder_id}&tab={tab_id}&refresh=Off&searchtype={search_type}&period={period}&timezone={timezone}&var-Dynamic+filters=%255B%255D&print=true{dashb_vars}",
             );
             log::debug!("dashb_url for dashboard {folder_id}/{dashboard_id}: {dashb_url}");
 
@@ -237,7 +248,7 @@ pub async fn generate_report(
         }
         ReportTimerangeType::Absolute => {
             let url = format!(
-                "{web_url}/dashboards/view?org_identifier={org_id}&dashboard={dashboard_id}&folder={folder_id}&tab={tab_id}&refresh=Off&searchtype=reports&from={}&to={}&timezone={timezone}&var-Dynamic+filters=%255B%255D&print=true{dashb_vars}",
+                "{web_url}/dashboards/view?org_identifier={org_id}&dashboard={dashboard_id}&folder={folder_id}&tab={tab_id}&refresh=Off&searchtype={search_type}&from={}&to={}&timezone={timezone}&var-Dynamic+filters=%255B%255D&print=true{dashb_vars}",
                 &timerange.from, &timerange.to
             );
             log::debug!("dashb_url for dashboard {folder_id}/{dashboard_id}: {url}");
@@ -307,12 +318,19 @@ pub async fn generate_report(
 
     // Last two elements loaded means atleast the metric components have loaded.
     // Convert the page into pdf
-    let pdf_data = page
-        .pdf(PrintToPdfParams {
-            landscape: Some(true),
-            ..Default::default()
-        })
-        .await?;
+    let pdf_data = match report_type {
+        ReportType::PDF => {
+            let pdf = page
+                .pdf(PrintToPdfParams {
+                    landscape: Some(true),
+                    ..Default::default()
+                })
+                .await?;
+            pdf
+        }
+        // No need to capture pdf when report type is cache
+        ReportType::Cache => vec![],
+    };
 
     browser.close().await?;
     handle.await?;


### PR DESCRIPTION
- [x] Empty destination array is supported for caching purpose. If destinations array is empty it only spawns a chromium and loads the dashboard, does not capture pdf.
- [x] For Cache type reports, it uses `ui` search type so that the dashboard queries land on only the interactive node and not  in the background node.