### PR TITLE
Remove git-hash from Docker image tag

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/buildcontainer.yml
+++ b/.github/workflows/buildcontainer.yml
@@ -195,7 +195,7 @@ jobs:
         - uses: int128/docker-manifest-create-action@v2
           with:
             tags: |
-              public.ecr.aws/zinclabs/report-server:${{ env.GIT_TAG }}-${{ env.GIT_HASH}}
+              public.ecr.aws/zinclabs/report-server:${{ env.GIT_TAG }}
             sources: |
               public.ecr.aws/zinclabs/report-server:${{ env.GIT_TAG }}-${{ env.GIT_HASH}}-amd64
               public.ecr.aws/zinclabs/report-server:${{ env.GIT_TAG }}-${{ env.GIT_HASH}}-arm64


### PR DESCRIPTION
- Removed `sha` env from final image.
- Add dependabot config to keep track of `github-actions` updates.

Fixes #3 

@hengfeiyang @Subhra264 