### PR TITLE
A bit better documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,135 +6,121 @@ Following are the ENVs related to chrome and SMTP. * means required -
 **ENVs**
 
 <table class="table table-striped table-bordered">
-
 <thead>
-
 <tr>
-
 <th>ENV</th>
-
 <th>Description</th>
-
+<th>Default</th>
 </tr>
-
 </thead>
-
 <tbody>
 
+<tr><td colspan="3"><strong>Authentication</strong></td></tr>
 <tr>
-
-<td>`ZO_CHROME_PATH`</td>
-
-<td>If chrome is enabled, custom `chrome` executable path can be specified. If not specified, it looks for chrome executable in default locations. If still not found, it automatically downloads a good known version of `chromium`.</td>
-
+<td><code>ZO_REPORT_USER_EMAIL</code>*</td>
+<td>Admin user email for report server access</td>
+<td></td>
+</tr>
+<tr>
+<td><code>ZO_REPORT_USER_PASSWORD</code>*</td>
+<td>Admin user password</td>
+<td></td>
 </tr>
 
+<tr><td colspan="3"><strong>HTTP Server</strong></td></tr>
 <tr>
+<td><code>ZO_HTTP_PORT</code></td>
+<td>Port for the HTTP server</td>
+<td>5090</td>
+</tr>
+<tr>
+<td><code>ZO_HTTP_ADDR</code></td>
+<td>Bind address for HTTP server</td>
+<td>127.0.0.1</td>
+</tr>
 
-<td>`ZO_CHROME_CHECK_DEFAULT_PATH`</td>
-
+<tr><td colspan="3"><strong>Chrome Settings</strong></td></tr>
+<tr>
+<td><code>ZO_CHROME_PATH</code></td>
+<td>Custom Chrome executable path</td>
+<td>Auto-detected</td>
+</tr>
+<tr>
+<td><code>ZO_CHROME_CHECK_DEFAULT_PATH</code></td>
 <td>If `false`, it does not look for chromium in default locations (e.g. `CHROME` env, usual chrome file path etc.), Default is `true`.</td>
-
+<td></td>
 </tr>
-
 <tr>
-
-<td>`ZO_CHROME_DOWNLOAD_PATH`</td>
-
+<td><code>ZO_CHROME_DOWNLOAD_PATH</code></td>
 <td>If chromium can not be found in default locations and also `ZO_CHROME_PATH` is not specified, it downloads the system specific chromium in the given path. Default is `./data/download` (gitignored). `chromium` is downloaded for the first time only, afterwords, `chromium` is fetched from the given path. If there is any error regarding download of `chromium`, delete the download folder as it might be in a bad state.</td>
-
+<td></td>
+</tr>
+<tr>
+<td><code>ZO_CHROME_NO_SANDBOX</code></td>
+<td>Disable Chrome sandbox</td>
+<td>false</td>
+</tr>
+<tr>
+<td><code>ZO_CHROME_SLEEP_SECS</code></td>
+<td>Timeout for dashboard loading</td>
+<td>20</td>
+</tr>
+<tr>
+<td><code>ZO_CHROME_WINDOW_WIDTH</code></td>
+<td>Browser window width</td>
+<td>1370</td>
+</tr>
+<tr>
+<td><code>ZO_CHROME_WINDOW_HEIGHT</code></td>
+<td>Browser window height</td>
+<td>730</td>
 </tr>
 
+<tr><td colspan="3"><strong>SMTP Settings</strong></td></tr>
 <tr>
-
-<td>`ZO_CHROME_NO_SANDBOX`</td>
-
-<td>If `true`, it launches chromium in `no-sandbox` environment. Default is `false`</td>
-
+<td><code>ZO_SMTP_HOST</code>*</td>
+<td>SMTP server host</td>
+<td>localhost</td>
 </tr>
-
 <tr>
-
-<td>`ZO_CHROME_SLEEP_SECS`</td>
-
-<td>Specify the number of timeout in seconds the headless chrome will wait until all the dashboard data is loaded. Default is `20` seconds.</td>
-
+<td><code>ZO_SMTP_PORT</code>*</td>
+<td>SMTP server port</td>
+<td>25</td>
 </tr>
-
 <tr>
-
-<td>`ZO_CHROME_WINDOW_WIDTH`</td>
-
-<td>Specifies the width of the headless chromium browser. Default is `1370`</td>
-
+<td><code>ZO_SMTP_USER_NAME</code>*</td>
+<td>SMTP authentication username</td>
+<td></td>
 </tr>
-
 <tr>
-
-<td>`ZO_CHROME_WINDOW_HEIGHT`</td>
-
-<td>Specifies the height of the headless chromium browser. Default is `730`</td>
-
+<td><code>ZO_SMTP_PASSWORD</code>*</td>
+<td>SMTP authentication password</td>
+<td></td>
 </tr>
-
 <tr>
-
-<td>`ZO_SMTP_HOST`*</td>
-
-<td>The SMTP Host. Default - `localhost`</td>
-
-</tr>
-
-<tr>
-
-<td>`ZO_SMTP_PORT`*</td>
-
-<td>SMTP port. Default - `25`</td>
-
-</tr>
-
-<tr>
-
-<td>`ZO_SMTP_USER_NAME`*</td>
-
-<td>SMTP user name.</td>
-
-</tr>
-
-<tr>
-
-<td>`ZO_SMTP_PASSWORD`*</td>
-
-<td>SMTP user password.</td>
-
-</tr>
-
-<tr>
-
-<td>`ZO_SMTP_REPLY_TO`</td>
-
+<td><code>ZO_SMTP_REPLY_TO</code></td>
 <td>The user email whom people can reply to. Not being used yet.</td>
-
+<td></td>
 </tr>
-
 <tr>
-
-<td>`ZO_SMTP_FROM_EMAIL`*</td>
-
+<td><code>ZO_SMTP_FROM_EMAIL</code>*</td>
 <td>The user email that is going to send the email.</td>
-
+<td></td>
+</tr>
+<tr>
+<td><code>ZO_SMTP_ENCRYPTION</code></td>
+<td>SMTP encryption method. Possible values - `starttls` and `ssltls` or can be ignored in case of `localhost:25`</td>
+<td></td>
 </tr>
 
+<tr><td colspan="3"><strong>General Settings</strong></td></tr>
 <tr>
-
-<td>`ZO_SMTP_ENCRYPTION`</td>
-
-<td>SMTP encryption method. Possible values - `starttls` and `ssltls` or can be ignored in case of `localhost:25`</td>
-
+<td><code>ZO_LOCAL_MODE</code></td>
+<td>Enable local storage mode</td>
+<td>true</td>
 </tr>
 
 </tbody>
-
 </table>
 
 **Example ENV setup**
@@ -142,6 +128,11 @@ Following are the ENVs related to chrome and SMTP. * means required -
 ```
 ZO_REPORT_USER_EMAIL = "root@example.com"
 ZO_REPORT_USER_PASSWORD = "Complexpass#123"
+
+# HTTP
+ZO_HTTP_PORT = 5090
+ZO_HTTP_ADDR = "127.0.0.1"
+ZO_HTTP_IPV6_ENABLED = false
 
 # SMTP
 ZO_SMTP_HOST = "smtp.gmail.com"
@@ -171,7 +162,7 @@ ZO_REPORT_SERVER_URL = http://localhost:5090
 # ZO_BASE_URI = "/abc"
 ```
 
-**Note:** If you don’t specify `ZO_CHROME_CHECK_DEFAULT_PATH` ENV, then before downloading chromium, it will look for chromium in default locations -
+**Note:** If you don't specify `ZO_CHROME_CHECK_DEFAULT_PATH` ENV, then before downloading chromium, it will look for chromium in default locations -
 
 1.  Check the CHROME env
 2.  Check usual chrome file names in user path


### PR DESCRIPTION
For example, HTTP config was present in `config.rs` but not in the readme