### PR TITLE
fix: return error if all the dashboard data could not be loaded

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,7 +399,21 @@ pub async fn generate_report(
             log::error!(
                 "[REPORT] error finding the span element for dashboard {dashboard_id}: {e}"
             );
-            log::info!("[REPORT] proceeding with whatever data is loaded until now");
+            let page_url = page.url().await;
+            take_screenshot(&page, org_id, dashboard_id, true).await?;
+            // Take a screenshot before killing the browser to help debug login issues
+            log::info!("killing browser");
+            browser.close().await?;
+            browser.wait().await?;
+            handle.await?;
+            browser.kill().await;
+            if let Err(e) = user_tmp_dir.close() {
+                log::error!("Error closing temporary directory for dashboard {dashboard_id}: {e}");
+            }
+            return Err(anyhow::anyhow!(
+                "[REPORT] error finding the span element for dashboard {dashboard_id}: {e}: current url: {:#?}. Some panels could not be loaded within the timeout.",
+                page_url
+            ));
         }
         Ok(dur) => {
             log::info!(


### PR DESCRIPTION
If some dashboards panel don't load within the given timeout, the report server simply logs that if not fully loaded, and proceeds with whatever is loaded. As a result, in the triggers stream in _meta organization, it shows this event as complete (even though it was partially complete). This pr changes this behaviour by returning error when the dashboard is not fully loaded.